### PR TITLE
Refactor: 공통 오류 응답(ErrorResponse) 만들기

### DIFF
--- a/DockerFile
+++ b/DockerFile
@@ -1,0 +1,17 @@
+FROM amazoncorretto:8 AS builder
+
+COPY gradlew .
+COPY gradle gradle
+COPY build.gradle .
+COPY settings.gradle .
+COPY src src
+
+RUN chmod +x ./gradlew
+RUN ./gradlew bootJar
+
+FROM amazoncorretto:8
+COPY --from=builder /build/libs/*.jar app.jar
+
+EXPOSE 8081
+ENTRYPOINT ["java", "-jar", "/app.jar"]
+VOLUME /app

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -19,6 +19,8 @@ services:
     volumes:
       - reservation-db:/var/lib/reservation/data
       - ./init.sql:/docker-entrypoint-initdb.d/init.sql
+    networks:
+      - reservation_network
     command:
       - "mysqld"
       - "--character-set-server=utf8mb4"
@@ -41,12 +43,44 @@ services:
     volumes:
       - reservation-test-db:/var/lib/reservation-test/data
       - ./init.sql:/docker-entrypoint-initdb.d/init.sql
+    networks:
+      - reservation_network
     command:
       - "mysqld"
       - "--character-set-server=utf8mb4"
       - "--collation-server=utf8mb4_unicode_ci"
     restart: always
 
+  app:
+    build:
+      context: ../
+      dockerfile: DockerFile
+    restart: always
+    env_file:
+      - ../env/total.env
+    depends_on:
+      - reservation-mysql
+      - reservation-test-mysql
+    ports:
+      - "8080:8080"
+    container_name: reservation_app
+    environment:
+      MYSQL_ROOT_PASSWORD: "${MYSQL_ROOT_PASSWORD}"
+      MYSQL_DATABASE: "${MYSQL_DATABASE}"
+      MYSQL_USER: "${MYSQL_USER}"
+      MYSQL_PASSWORD: "${MYSQL_PASSWORD}"
+
+      MYSQL_TEST_DATABASE: "${MYSQL_TEST_DATABASE}"
+      MYSQL_TEST_USER: "${MYSQL_TEST_USER}"
+      MYSQL_TEST_PASSWORD: "${MYSQL_TEST_PASSWORD}"
+    networks:
+      - reservation_network
+
+
 volumes:
   reservation-db:
   reservation-test-db:
+  app:
+
+networks:
+  reservation_network:

--- a/src/main/java/com/example/reservation/common/ErrorResponse.java
+++ b/src/main/java/com/example/reservation/common/ErrorResponse.java
@@ -1,0 +1,40 @@
+package com.example.reservation.common;
+
+import static java.util.Collections.*;
+import static java.util.stream.Collectors.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.validation.FieldError;
+
+import lombok.Getter;
+
+@Getter
+public class ErrorResponse {
+	private final String message;
+	private final String path;
+	private final LocalDateTime time;
+	private final List<FieldErrorMessage> fieldErrorMessages;
+
+	private ErrorResponse(
+			String message, String path, LocalDateTime time, List<FieldError> fieldErrors
+	) {
+		this.message = message;
+		this.path = path;
+		this.time = time;
+		this.fieldErrorMessages = fieldErrors.stream()
+				.map(FieldErrorMessage::new)
+				.collect(toList());
+	}
+
+	public static ErrorResponse of(String message, String path) {
+		return new ErrorResponse(message, path, LocalDateTime.now(), emptyList());
+	}
+
+	public static ErrorResponse of(
+			String message, String path, List<FieldError> inputErrors
+	) {
+		return new ErrorResponse(message, path, LocalDateTime.now(), inputErrors);
+	}
+}

--- a/src/main/java/com/example/reservation/common/FieldErrorMessage.java
+++ b/src/main/java/com/example/reservation/common/FieldErrorMessage.java
@@ -1,0 +1,46 @@
+package com.example.reservation.common;
+
+import javax.validation.constraints.NotNull;
+
+import org.springframework.lang.Nullable;
+import org.springframework.validation.FieldError;
+
+import lombok.Getter;
+
+@Getter
+public class FieldErrorMessage {
+
+	private final String objectName;
+	private final String field;
+	private final String message;
+	@Nullable
+	private final Object rejectedValue;
+	private final String code;
+
+	public FieldErrorMessage(
+			String objectName, String field, String message, @Nullable Object rejectedValue, String code
+	) {
+		this.objectName = objectName;
+		this.field = field;
+		this.message = message;
+		this.rejectedValue = rejectedValue;
+		this.code = code;
+	}
+
+	public FieldErrorMessage(@NotNull FieldError fieldError) {
+		this(fieldError.getObjectName(), fieldError.getField(), fieldError.getDefaultMessage(),
+				fieldError.getRejectedValue(), fieldError.getCode()
+		);
+	}
+
+	@Override
+	public String toString() {
+		return "FieldErrorMessage{" +
+				"objectName='" + objectName + '\'' +
+				", field='" + field + '\'' +
+				", message='" + message + '\'' +
+				", rejectedValue=" + rejectedValue +
+				", code='" + code + '\'' +
+				'}';
+	}
+}

--- a/src/main/java/com/example/reservation/common/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/reservation/common/GlobalExceptionHandler.java
@@ -1,11 +1,16 @@
 package com.example.reservation.common;
 
+import java.util.List;
+
 import javax.persistence.EntityNotFoundException;
+import javax.servlet.http.HttpServletRequest;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -15,30 +20,67 @@ import lombok.extern.slf4j.Slf4j;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 	@ExceptionHandler({BadCredentialsException.class, UsernameNotFoundException.class})
-	public ResponseEntity<String> unAuthorizedExceptionHandler(Exception e) {
+	public ResponseEntity<ErrorResponse> unAuthorizedExceptionHandler(HttpServletRequest request, Exception e) {
 		printException(e);
-		return new ResponseEntity<>(e.getMessage(), HttpStatus.UNAUTHORIZED);
+		return new ResponseEntity<>(
+				ErrorResponse.of(e.getMessage(), request.getRequestURI()),
+				HttpStatus.UNAUTHORIZED
+		);
 	}
 
 	@ExceptionHandler({IllegalArgumentException.class, EntityNotFoundException.class})
-	public ResponseEntity<String> badRequestExceptionHandler(Exception e) {
+	public ResponseEntity<ErrorResponse> badRequestExceptionHandler(HttpServletRequest request, Exception e) {
 		printException(e);
-		return new ResponseEntity<>(e.getMessage(), HttpStatus.BAD_REQUEST);
+		return new ResponseEntity<>(
+				ErrorResponse.of(e.getMessage(), request.getRequestURI()),
+				HttpStatus.BAD_REQUEST
+		);
+	}
+
+	@ExceptionHandler(MethodArgumentNotValidException.class)
+	public ResponseEntity<ErrorResponse> methodArgumentNotValidExceptionHandler(HttpServletRequest request,
+			MethodArgumentNotValidException e) {
+		printException(e);
+		List<FieldError> fieldErrors = e.getBindingResult().getFieldErrors();
+
+		StringBuilder errorMessage = new StringBuilder();
+		errorMessage.append("validation failed fields: [ ");
+
+		int size = fieldErrors.size();
+		for (int i = 0; i < size; i++) {
+			errorMessage.append(fieldErrors.get(i).getField());
+			if (i == size - 1) {
+				continue;
+			}
+			errorMessage.append(", ");
+		}
+		errorMessage.append(" ]");
+
+		return new ResponseEntity<>(
+				ErrorResponse.of(errorMessage.toString(), request.getRequestURI(), fieldErrors),
+				HttpStatus.BAD_REQUEST
+		);
 	}
 
 	@ExceptionHandler(RuntimeException.class)
-	public ResponseEntity<String> runtimeExceptionHandler(RuntimeException e) {
+	public ResponseEntity<ErrorResponse> runtimeExceptionHandler(HttpServletRequest request, RuntimeException e) {
 		printException(e);
-		return new ResponseEntity<>(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+		return new ResponseEntity<>(
+				ErrorResponse.of(e.getMessage(), request.getRequestURI()),
+				HttpStatus.INTERNAL_SERVER_ERROR
+		);
 	}
 
 	@ExceptionHandler(Exception.class)
-	public ResponseEntity<String> exceptionHandler(Exception e) {
+	public ResponseEntity<ErrorResponse> exceptionHandler(HttpServletRequest request, Exception e) {
 		printException(e);
-		return new ResponseEntity<>(e.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+		return new ResponseEntity<>(
+				ErrorResponse.of(e.getMessage(), request.getRequestURI()),
+				HttpStatus.INTERNAL_SERVER_ERROR
+		);
 	}
 
 	private void printException(Exception e) {
-		log.info("{} handled", e.toString());
+		log.info("{}", e.toString());
 	}
 }

--- a/src/main/java/com/example/reservation/common/exception/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/example/reservation/common/exception/CustomAccessDeniedHandler.java
@@ -1,0 +1,48 @@
+package com.example.reservation.common.exception;
+
+import static org.springframework.http.MediaType.*;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+import com.example.reservation.common.ErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+	@Override
+	public void handle(HttpServletRequest request, HttpServletResponse response,
+			AccessDeniedException accessDeniedException) throws IOException {
+		log.info("URL = {}, Exception = {}, Message = {}",
+				request.getRequestURI(), accessDeniedException.getClass().getSimpleName(), accessDeniedException.getMessage()
+		);
+
+		response.setCharacterEncoding("UTF-8");
+		response.setContentType(APPLICATION_JSON.toString());
+		response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+
+		ErrorResponse errorResponse = ErrorResponse.of(
+				accessDeniedException.getMessage(),
+				request.getRequestURI()
+		);
+
+		ObjectMapper objectMapper = new ObjectMapper();
+		objectMapper.registerModule(new JavaTimeModule());
+		objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+		PrintWriter writer = response.getWriter();
+		writer.write(objectMapper.writeValueAsString(errorResponse));
+		writer.flush();
+		writer.close();
+	}
+}

--- a/src/main/java/com/example/reservation/common/exception/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/reservation/common/exception/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,45 @@
+package com.example.reservation.common.exception;
+
+import static org.springframework.http.MediaType.*;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import com.example.reservation.common.ErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+	@Override
+	public void commence(HttpServletRequest request, HttpServletResponse response,
+			AuthenticationException authException) throws IOException {
+		response.setCharacterEncoding("UTF-8");
+		response.setContentType(APPLICATION_JSON.toString());
+		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+		ErrorResponse errorResponse = ErrorResponse.of(
+				authException.getMessage(),
+				request.getRequestURI()
+		);
+
+		response.setCharacterEncoding("UTF-8");
+		response.setContentType(APPLICATION_JSON.toString());
+		response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+		ObjectMapper objectMapper = new ObjectMapper();
+		objectMapper.registerModule(new JavaTimeModule());
+		objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+		PrintWriter writer = response.getWriter();
+		writer.write(objectMapper.writeValueAsString(errorResponse));
+		writer.flush();
+		writer.close();
+	}
+}

--- a/src/main/java/com/example/reservation/config/SecurityConfig.java
+++ b/src/main/java/com/example/reservation/config/SecurityConfig.java
@@ -11,10 +11,15 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.session.SessionRegistry;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.savedrequest.NullRequestCache;
 import org.springframework.session.jdbc.JdbcIndexedSessionRepository;
 import org.springframework.session.security.SpringSessionBackedSessionRegistry;
+
+import com.example.reservation.common.exception.CustomAccessDeniedHandler;
+import com.example.reservation.common.exception.CustomAuthenticationEntryPoint;
 
 import lombok.RequiredArgsConstructor;
 
@@ -35,6 +40,16 @@ public class SecurityConfig {
 	@Bean
 	PasswordEncoder bCryptPasswordEncoder() {
 		return new BCryptPasswordEncoder();
+	}
+
+	@Bean
+	AuthenticationEntryPoint authenticationEntryPoint() {
+		return new CustomAuthenticationEntryPoint();
+	}
+
+	@Bean
+	AccessDeniedHandler accessDeniedHandler() {
+		return new CustomAccessDeniedHandler();
 	}
 
 	@Bean
@@ -68,6 +83,10 @@ public class SecurityConfig {
 				.maximumSessions(1)
 				.sessionRegistry(springSessionBackedSessionRegistry(jdbcIndexedSessionRepository))
 				.and()
+				.and()
+				.exceptionHandling()
+				.authenticationEntryPoint(authenticationEntryPoint())
+				.accessDeniedHandler(accessDeniedHandler())
 				.and()
 				.requestCache().requestCache(new NullRequestCache())
 				.and()

--- a/src/main/resources/application-db.yml
+++ b/src/main/resources/application-db.yml
@@ -5,7 +5,7 @@ spring:
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:${MYSQL_PORT}/${MYSQL_DATABASE}
+    url: jdbc:mysql://${HOST_NAME}:${MYSQL_PORT}/${MYSQL_DATABASE}
     username: ${MYSQL_USER}
     password: ${MYSQL_PASSWORD}
 

--- a/src/test/resources/application-testdb.yml
+++ b/src/test/resources/application-testdb.yml
@@ -5,7 +5,7 @@ spring:
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:${MYSQL_TEST_PORT}/${MYSQL_TEST_DATABASE}
+    url: jdbc:mysql://${TEST_HOST_NAME}:${MYSQL_TEST_PORT}/${MYSQL_TEST_DATABASE}
     username: ${MYSQL_TEST_USER}
     password: ${MYSQL_TEST_PASSWORD}
 


### PR DESCRIPTION
- close #1 

# 내용
- `ErrorResponse` 공통 오류 응답 추가
- binding 실패에 대한 정보를 담은 `FieldErrorMessage` 추가
- `CustomAccessDeniedHandler`, `CustomAuthenticationEntryPoint` 추가 및 적용


# 고민해 볼 점
- `ErrorResponse`에 담을 정보에 대한 고민 : HTTP 응답에 이미 `HttpStatus`와 시간이 Http 응답 header에 담기니, 
굳이 `ErrorResposne에 시간과 `HttpStatus`를 담을 필요가 없다는 피드백을 받은적이 있다 
프론트를 다루어 본 적이 없다 보니 어떤것이 프론트 입장에서 좋은지 모르겠다.

- Spring Security Filter를 이용해 권한을 인가 검사를 하게 되면, 인증되지 않은 객체에 대해서는 `exceptionHandling().accessDeniedHandler(customAccessDeniedHanlder())`에서 정해준 
`customAccessDeniedHandler`가 아닌  `Http403ForbiddenEntryPoint`가 뱉어주는 오류 응답이 나가게 된다. 
[.accessDeniedHandler(accessDeniedHandler())로 설정해준 오류 응답이 나가지 않는 이유](https://github.com/BnDC/reservation/wiki/.accessDeniedHandler(accessDeniedHandler())%EB%A1%9C-%EC%84%A4%EC%A0%95%ED%95%B4%EC%A4%80-%EC%98%A4%EB%A5%98-%EC%9D%91%EB%8B%B5%EC%9D%B4-%EB%82%98%EA%B0%80%EC%A7%80-%EC%95%8A%EB%8A%94-%EC%9D%B4%EC%9C%A0)


# 문제점 및 개선점
- 오류에 대한 응답을 할 때, 단순히 exception message만이 아닌 보다 상세한 정보를 제공할 수 있도록 변경하였다.
- binding 실패, validation 실패로 인한 오류 응답을 보기 편하도록 개선하였다.