### PR TITLE
Fix: SecurityConfig 누락된 설정 추가 및 CustomUserDetails 오타 수정

### DIFF
--- a/src/main/java/com/example/reservation/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/reservation/common/exception/GlobalExceptionHandler.java
@@ -19,7 +19,11 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
-	@ExceptionHandler({BadCredentialsException.class, UsernameNotFoundException.class})
+	@ExceptionHandler({
+			BadCredentialsException.class,
+			UsernameNotFoundException.class,
+			InsufficientAuthenticationException.class
+	})
 	public ResponseEntity<ErrorResponse> unAuthorizedExceptionHandler(HttpServletRequest request, Exception e) {
 		printException(e);
 		return new ResponseEntity<>(

--- a/src/main/java/com/example/reservation/common/util/AuthenticationUtil.java
+++ b/src/main/java/com/example/reservation/common/util/AuthenticationUtil.java
@@ -2,12 +2,16 @@ package com.example.reservation.common.util;
 
 import java.util.Collection;
 
+import org.springframework.security.authentication.InsufficientAuthenticationException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 
 import com.example.reservation.domain.member.model.CustomUserDetails;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 public class AuthenticationUtil {
 	public static String getUsername() {
 		return getUserDetails().getUsername();
@@ -24,7 +28,8 @@ public class AuthenticationUtil {
 	private static CustomUserDetails getUserDetails() {
 		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 		if (authentication == null || authentication.getPrincipal().equals("anonymousUser")) {
-			throw new IllegalArgumentException("인증되지 않은 객체입니다");
+			log.debug("[AuthenticationUtil] can't get userDetails");
+			throw new InsufficientAuthenticationException("It should have authenticated");
 		}
 		return (CustomUserDetails)authentication.getPrincipal();
 	}

--- a/src/main/java/com/example/reservation/config/SecurityConfig.java
+++ b/src/main/java/com/example/reservation/config/SecurityConfig.java
@@ -27,7 +27,6 @@ import lombok.RequiredArgsConstructor;
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
-
 	private final JdbcIndexedSessionRepository jdbcIndexedSessionRepository;
 
 	@Bean
@@ -67,7 +66,7 @@ public class SecurityConfig {
 	public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
 		return httpSecurity
 				.authorizeRequests()
-				.antMatchers("/api/**/business/**").hasAuthority("USER")
+				.antMatchers("/api/**/business/**", "/api/**/reservations/**").hasAuthority("USER")
 				.antMatchers(POST, "/api/**/theaters/**").hasAuthority("THEATER_BUSINESS")
 				.antMatchers(POST, "/api/**/movies/**", "/api/**/schedules/**").hasAuthority("PERFORMANCE_BUSINESS")
 				.and()

--- a/src/main/java/com/example/reservation/domain/member/model/CustomUserDetails.java
+++ b/src/main/java/com/example/reservation/domain/member/model/CustomUserDetails.java
@@ -26,7 +26,7 @@ public class CustomUserDetails implements UserDetails {
 
 	@Override
 	public String getUsername() {
-		return userDetails.getPassword();
+		return userDetails.getUsername();
 	}
 
 	@Override


### PR DESCRIPTION
- close #2 

# 내용
- SecurityConfig reservation 관련된 api에 USER 권한 검사 하도록 설정
- `CustomUserDetails.getUsername()`에 있던 오타인해 로그인이 되지 않는 문제 해결
- `AuthentiationUtil.getUserDetails.getUserDetails`에서 인증이 안되었을 때, 발생하는 `Exception` 을 `IllegalArgumentException` 에서 `InsufficientAuthenticationExceptioin`으로 수정

# 고민해 볼 점
- `AuthentiationUtil.getUserDetails.getUserDetails`은 인증이 완료 되어 Authentication 객체가 잘 담겼다는 것을 가정하고, UserDetails를 꺼낸다.
- 인가를 담당하는 필터에서, 미쳐 거르지 못해 인증 객체가 제대로 담기지 않을 가능성이 있다.
- 그 경우 어떤 `Exception`을 내보내야 할지 고민하다가, `Authentication` 객체가 올바르지 않으니 `IllegalArgumentException`을 내보내도록 했었다. (이 경우 `Authentication`을 전달 받은 것이 아니기 때문에 부자연스럽다고 생각된다. 굳이 사용한다면 `IllegalStateException`이 더 나았을 것 같다.)
- 그러나 Authentication이 제대로 담겼어야 했는데 그렇지 않은 것, 즉 인증되지 않은 것이 문제이니 
`AuthenticationException`과 관련된 `Exception`을 내보는 것이 더 좋을 거 같다.
- 그래서 `AuthenticationException`을 상속받은 `NotAuthenticatedException`을 만들어 사용할 생각이었는데, `ExceptionTranslationFilter`를 내부에서 `InsufficientAuthenticationException`을 사용하고 있었다.
- CustomException을 만들기 보다는 의미가 통하는 Exception이 있다면 그것을 사용하는 것이 나을 가 같다고 판단해 최종적으로 `InsufficientAuthenticationException`을 사용했다.


# 문제점 및 개선점
- 로그인이 되지 않는 문제 해결